### PR TITLE
Move TESTS to check_PROGRAMS

### DIFF
--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -94,7 +94,7 @@ TESTS += \
 	test_triggered_ME_ops
 endif
 
-noinst_PROGRAMS = $(TESTS)
+check_PROGRAMS = $(TESTS)
 
 NPROCS ?= 2
 LOG_COMPILER = $(TEST_RUNNER)

--- a/test/sfw/Makefile.am
+++ b/test/sfw/Makefile.am
@@ -10,7 +10,7 @@ XMLEXTRA = \
 
 EXTRA_DIST = $(XMLEXTRA) make_test_relay.pl
 
-noinst_PROGRAMS = ptl_test make_test_atomic make_test_swap make_test_move test
+check_PROGRAMS = ptl_test make_test_atomic make_test_swap make_test_move test
 
 # Each binary needs the portals library and the runtime
 PORTALSLIB = $(top_builddir)/src/libportals.la $(top_builddir)/test/libtestsupport.la


### PR DESCRIPTION
Move tests from noinst_PROGRAMS to check_PROGRAMS so they are not built
during "make all".  This change should improve the performane of CI
testing.

Signed-off-by: James Dinan <james.dinan@intel.com>